### PR TITLE
chore!: drop support for node 12; add support for node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
     steps:
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
BREAKING CHANGE: Drops support for EOL node 12; adds support for node 18