### PR TITLE
feat: add possibility to transform data in syslog entry

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -151,7 +151,9 @@ $ npm install --production -g pino-syslog
   "tz": "UTC",
   "newline": false,
   "structuredData": "-",
-  "sync": false
+  "sync": false,
+  "filterProperties": [],
+  "levelAsText": false,
 }
 ```
 
@@ -173,6 +175,9 @@ This also shows the full structure of a configuration file, which can be loaded 
 + `--newline` (`-n`) (boolean): terminate with a newline
 + `--structuredData` (`-s`) (string): [structured data](https://tools.ietf.org/html/rfc5424#section-6.3) to send with an RFC5424 message.
 + `--sync` (`-sy`) (boolean): perform writes synchronously
++ `--filterProperties` (array<string>): a list of property names from the original *pino* log to exclude from the formatted
+  message. This is only applicable if `messageOnly` is `false`.
++ `--levelAsText` (`-l`) (boolean): if `true`, the `level` property of the *pino* log is sent as a string instead of a number.
 
 [facility]: https://tools.ietf.org/html/rfc3164#section-4.1.1
 [tzstring]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/lib/rfc3164.js
+++ b/lib/rfc3164.js
@@ -15,6 +15,14 @@ function messageBuilderFactory (options) {
     }
     const hostname = data.hostname.split('.')[0]
     const header = `<${pri}>${timestamp} ${hostname} ${options.appname}[${data.pid}]: `
+    if (options.levelAsText) {
+      data.level = options.pinoLabels.get(data.level)
+    }
+    if (options.filterProperties.length > 0) {
+      for (const key of options.filterProperties) {
+        delete data[key]
+      }
+    }
     const message = buildMessage(data, header.length)
     return (options.cee && !options.messageOnly)
       ? `${header}@cee: ${message}${options.newline ? '\n' : ''}`

--- a/lib/rfc5424.js
+++ b/lib/rfc5424.js
@@ -18,6 +18,14 @@ function messageBuilderFactory (options) {
     const msgid = (data.req && data.req.id) ? data.req.id : '-'
     const structuredData = options.structuredData || '-'
     const header = `<${pri}>${version} ${tstamp} ${hostname} ${appname} ${data.pid} ${msgid} ${structuredData} `
+    if (options.levelAsText) {
+      data.level = options.pinoLabels.get(data.level)
+    }
+    if (options.filterProperties.length > 0) {
+      for (const key of options.filterProperties) {
+        delete data[key]
+      }
+    }
     const message = buildMessage(data)
     return (options.cee && !options.messageOnly)
       ? `${header}@cee: ${message}${options.newline ? '\n' : ''}`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,14 @@
 'use strict'
 
+const pinoLabels = new Map([
+  [60, 'fatal'],
+  [50, 'error'],
+  [40, 'warn'],
+  [30, 'info'],
+  [20, 'debug'],
+  [10, 'trace']
+])
+
 const pinoLevels = {
   fatal: 60,
   error: 50,
@@ -45,7 +54,10 @@ const defaults = {
   tz: 'UTC',
   newline: false,
   sync: false,
-  pinoLevelToSyslogSeverity
+  filterProperties: [],
+  levelAsText: false,
+  pinoLevelToSyslogSeverity,
+  pinoLabels
 }
 
 /**

--- a/psyslog.js
+++ b/psyslog.js
@@ -18,7 +18,9 @@ const longOpts = {
   newline: Boolean,
   structuredData: String,
   config: String,
-  sync: Boolean
+  sync: Boolean,
+  filterProperties: String,
+  levelAsText: Boolean
 }
 
 const shortOpts = {
@@ -30,7 +32,8 @@ const shortOpts = {
   n: '--newline',
   s: '--structuredData',
   c: '--config',
-  sy: '--sync'
+  sy: '--sync',
+  l: '--levelAsText'
 }
 
 const args = nopt(longOpts, shortOpts)


### PR DESCRIPTION
The idea of this PR is to allow:

* using labels instead of numbers for the level
* filtering out some properties in the data (e.g. time and hostname that are already in the syslog fields and redundant in the message)

For example:

```
const options = { levelAsText: true, filterProperties: ['time', 'hostname'] };
logger.warn({ foo: "bar" }, "plop");
// will print: <156>1 2025-04-03T13:42:15Z localhost template-builder 52724 - - {"level":"warn","pid":52724,"name":"FooLogger","foo":"bar","message":"plop"}
```